### PR TITLE
Trim settingsString on import

### DIFF
--- a/packages/client/js/shared.js
+++ b/packages/client/js/shared.js
@@ -760,9 +760,9 @@
     }
     if (version >= 3) {
       // `openMap' and 'spinnerSpeed' and 'opendot' were added as options in version 3
-    processBasic({ id: 'OpenMap' });
-    processBasic({ id: 'increaseSpinnerSpeed' });
-    processBasic({ id: 'opendot' });
+      processBasic({ id: 'OpenMap' });
+      processBasic({ id: 'increaseSpinnerSpeed' });
+      processBasic({ id: 'opendot' });
     }
 
     res.startingItems = processor.nextEolList(9);
@@ -832,6 +832,10 @@
   // }
 
   function decodeSettingsString(settingsString) {
+    if (settingsString) {
+      settingsString = settingsString.trim();
+    }
+
     const byType = breakUpSettingsString(settingsString);
 
     const result = {};


### PR DESCRIPTION
- Trim when decoding settings so if you manually copy the string and it has whitespace at the front or end, the import won't fail.
- Format file.