### PR TITLE
Add more options for shuffling Poes

### DIFF
--- a/Generator/Assets/Checks.cs
+++ b/Generator/Assets/Checks.cs
@@ -377,11 +377,39 @@ namespace TPRandomizer
                     }
                 }
 
-                if (!parseSetting.shufflePoes)
+                switch (parseSetting.shufflePoes)
                 {
-                    if (currentCheck.category.Contains("Poe"))
+                    case PoeSettings.Vanilla:
                     {
-                        currentCheck.checkStatus = "Vanilla";
+                        if (currentCheck.category.Contains("Poe"))
+                        {
+                            currentCheck.checkStatus = "Vanilla";
+                        }
+                        break;
+                    }
+
+                    case PoeSettings.Overworld:
+                    {
+                        if (
+                            currentCheck.category.Contains("Poe")
+                            && !currentCheck.category.Contains("Overworld")
+                        )
+                        {
+                            currentCheck.checkStatus = "Vanilla";
+                        }
+                        break;
+                    }
+
+                    case PoeSettings.Dungeons:
+                    {
+                        if (
+                            currentCheck.category.Contains("Poe")
+                            && !currentCheck.category.Contains("Dungeon")
+                        )
+                        {
+                            currentCheck.checkStatus = "Vanilla";
+                        }
+                        break;
                     }
                 }
 

--- a/Generator/Assets/Items.cs
+++ b/Generator/Assets/Items.cs
@@ -764,9 +764,25 @@ namespace TPRandomizer
             Randomizer.Items.BaseItemPool.AddRange(this.VanillaDungeonRewards);
             Randomizer.Items.ShuffledDungeonRewards.AddRange(this.VanillaDungeonRewards);
 
-            if (parseSetting.shufflePoes)
+            switch (parseSetting.shufflePoes)
             {
-                this.RandomizedImportantItems.AddRange(Enumerable.Repeat(Item.Poe_Soul, 60));
+                case PoeSettings.Overworld:
+                {
+                    this.RandomizedImportantItems.AddRange(Enumerable.Repeat(Item.Poe_Soul, 49));
+                    break;
+                }
+
+                case PoeSettings.Dungeons:
+                {
+                    this.RandomizedImportantItems.AddRange(Enumerable.Repeat(Item.Poe_Soul, 11));
+                    break;
+                }
+
+                case PoeSettings.All:
+                {
+                    this.RandomizedImportantItems.AddRange(Enumerable.Repeat(Item.Poe_Soul, 60));
+                    break;
+                }
             }
 
             if (parseSetting.shuffleGoldenBugs)
@@ -1004,9 +1020,39 @@ namespace TPRandomizer
             {
                 if (Randomizer.Checks.CheckDict[excludedCheck].itemId == Item.Poe_Soul)
                 {
-                    if (!parseSetting.shufflePoes)
+                    switch (parseSetting.shufflePoes)
                     {
-                        Randomizer.Checks.CheckDict[excludedCheck].checkStatus = "Vanilla";
+                        case PoeSettings.Vanilla:
+                        {
+                            Randomizer.Checks.CheckDict[excludedCheck].checkStatus = "Vanilla";
+                            break;
+                        }
+
+                        case PoeSettings.Overworld:
+                        {
+                            if (
+                                !Randomizer.Checks.CheckDict[excludedCheck].category.Contains(
+                                    "Overworld"
+                                )
+                            )
+                            {
+                                Randomizer.Checks.CheckDict[excludedCheck].checkStatus = "Vanilla";
+                            }
+                            break;
+                        }
+
+                        case PoeSettings.Dungeons:
+                        {
+                            if (
+                                !Randomizer.Checks.CheckDict[excludedCheck].category.Contains(
+                                    "Dungeon"
+                                )
+                            )
+                            {
+                                Randomizer.Checks.CheckDict[excludedCheck].checkStatus = "Vanilla";
+                            }
+                            break;
+                        }
                     }
                 }
             }

--- a/Generator/Glitched-World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds East Turning Room Poe.jsonc
+++ b/Generator/Glitched-World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds East Turning Room Poe.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal and (Progressive_Clawshot, 1)",
     "stageIDX": [24],
     "flag": "1F",
-    "category": ["Overworld", "Poe", "Arbiters Grounds"],
+    "category": ["Dungeon", "Poe", "Arbiters Grounds"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/Glitched-World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds Hidden Wall Poe.jsonc
+++ b/Generator/Glitched-World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds Hidden Wall Poe.jsonc
@@ -2,6 +2,6 @@
   "requirements": "Shadow_Crystal and CanDefeatRedeadKnight and ((Arbiters_Grounds_Small_Key, 3) or (Setting.smallKeySettings equals Keysy))",
   "stageIDX": [ 24 ],
   "flag": "20",
-  "category": [ "Overworld", "Poe", "Arbiters Grounds" ],
+  "category": [ "Dungeon", "Poe", "Arbiters Grounds" ],
   "itemId": "Poe_Soul"
 }

--- a/Generator/Glitched-World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds Torch Room Poe.jsonc
+++ b/Generator/Glitched-World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds Torch Room Poe.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal",
     "stageIDX": [24],
     "flag": "1E",
-    "category": ["Overworld", "Poe", "Arbiters Grounds"],
+    "category": ["Dungeon", "Poe", "Arbiters Grounds"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/Glitched-World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds West Poe.jsonc
+++ b/Generator/Glitched-World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds West Poe.jsonc
@@ -2,6 +2,6 @@
   "requirements": "Shadow_Crystal and canSmash and ((Arbiters_Grounds_Small_Key, 4) or (Setting.smallKeySettings equals Keysy)) and CanDefeatRedeadKnight and CanDefeatStalchild and CanDefeatBubble and CanDefeatGhoulRat",
   "stageIDX": [ 24 ],
   "flag": "21",
-  "category": [ "Overworld", "Poe", "Arbiters Grounds" ],
+  "category": [ "Dungeon", "Poe", "Arbiters Grounds" ],
   "itemId": "Poe_Soul"
 }

--- a/Generator/Glitched-World/Checks/Dungeons/City in The Sky/City in The Sky Garden Island Poe.jsonc
+++ b/Generator/Glitched-World/Checks/Dungeons/City in The Sky/City in The Sky Garden Island Poe.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal and (Progressive_Clawshot, 2)",
     "stageIDX": [12],
     "flag": "54",
-    "category": ["Overworld", "Poe", "City in The Sky"],
+    "category": ["Dungeon", "Poe", "City in The Sky"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/Glitched-World/Checks/Dungeons/City in The Sky/City in The Sky Poe Above Central Fan.jsonc
+++ b/Generator/Glitched-World/Checks/Dungeons/City in The Sky/City in The Sky Poe Above Central Fan.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal and CanDefeatWalltula",
     "stageIDX": [12],
     "flag": "55",
-    "category": ["Overworld", "Poe", "City in The Sky"],
+    "category": ["Dungeon", "Poe", "City in The Sky"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/Glitched-World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Ice Room Poe.jsonc
+++ b/Generator/Glitched-World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Ice Room Poe.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal",
     "stageIDX": [27],
     "flag": "7F",
-    "category": ["Overworld", "Poe", "Snowpeak Ruins"],
+    "category": ["Dungeon", "Poe", "Snowpeak Ruins"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/Glitched-World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Lobby Armor Poe.jsonc
+++ b/Generator/Glitched-World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Lobby Armor Poe.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal and Ball_and_Chain",
     "stageIDX": [27],
     "flag": "15",
-    "category": ["Overworld", "Poe", "Snowpeak Ruins"],
+    "category": ["Dungeon", "Poe", "Snowpeak Ruins"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/Glitched-World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Lobby Poe.jsonc
+++ b/Generator/Glitched-World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Lobby Poe.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal",
     "stageIDX": [27],
     "flag": "72",
-    "category": ["Overworld", "Poe", "Snowpeak Ruins"],
+    "category": ["Dungeon", "Poe", "Snowpeak Ruins"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/Glitched-World/Checks/Dungeons/Temple of Time/Temple of Time Poe Above Scales.jsonc
+++ b/Generator/Glitched-World/Checks/Dungeons/Temple of Time/Temple of Time Poe Above Scales.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal and (Progressive_Clawshot, 1) and Spinner",
     "stageIDX": [9],
     "flag": "18",
-    "category": ["Overworld", "Poe", "Temple of Time"],
+    "category": ["Dungeon", "Poe", "Temple of Time"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/Glitched-World/Checks/Dungeons/Temple of Time/Temple of Time Poe Behind Gate.jsonc
+++ b/Generator/Glitched-World/Checks/Dungeons/Temple of Time/Temple of Time Poe Behind Gate.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal and (Progressive_Dominion_Rod, 1)",
     "stageIDX": [9],
     "flag": "19",
-    "category": ["Overworld", "Poe", "Temple of Time"],
+    "category": ["Dungeon", "Poe", "Temple of Time"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/Logic/SSettingsEnums.cs
+++ b/Generator/Logic/SSettingsEnums.cs
@@ -90,4 +90,12 @@ namespace TPRandomizer.SSettings.Enums
         Minimal = 1,
         Plentiful = 2,
     }
+
+    public enum PoeSettings
+    {
+        Vanilla = 0,
+        Overworld = 1,
+        Dungeons = 2,
+        All = 3
+    }
 }

--- a/Generator/Logic/SeedGenResults.cs
+++ b/Generator/Logic/SeedGenResults.cs
@@ -306,7 +306,7 @@ namespace TPRandomizer
             result.Add("shuffleGoldenBugs", sSettings.shuffleGoldenBugs);
             result.Add("shuffleSkyCharacters", sSettings.shuffleSkyCharacters);
             result.Add("shuffleNpcItems", sSettings.shuffleNpcItems);
-            result.Add("shufflePoes", sSettings.shufflePoes);
+            result.Add("shufflePoes", sSettings.shufflePoes.ToString());
             result.Add("shuffleShopItems", sSettings.shuffleShopItems);
             result.Add("shuffleHiddenSkills", sSettings.shuffleHiddenSkills);
             result.Add("itemScarcity", sSettings.itemScarcity.ToString());

--- a/Generator/Logic/SharedSettings.cs
+++ b/Generator/Logic/SharedSettings.cs
@@ -21,7 +21,7 @@ namespace TPRandomizer
         public bool shuffleGoldenBugs { get; set; }
         public bool shuffleSkyCharacters { get; set; }
         public bool shuffleNpcItems { get; set; }
-        public bool shufflePoes { get; set; }
+        public PoeSettings shufflePoes { get; set; }
         public bool shuffleShopItems { get; set; }
         public bool shuffleHiddenSkills { get; set; }
         public SmallKeySettings smallKeySettings { get; set; }
@@ -67,7 +67,7 @@ namespace TPRandomizer
             shuffleGoldenBugs = processor.NextBool();
             shuffleSkyCharacters = processor.NextBool();
             shuffleNpcItems = processor.NextBool();
-            shufflePoes = processor.NextBool();
+            shufflePoes = (PoeSettings)processor.NextInt(2);
             shuffleShopItems = processor.NextBool();
             shuffleHiddenSkills = processor.NextBool();
             smallKeySettings = (SmallKeySettings)processor.NextInt(3);

--- a/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds East Turning Room Poe.jsonc
+++ b/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds East Turning Room Poe.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal and (Progressive_Clawshot, 1)",
     "stageIDX": [24],
     "flag": "1F",
-    "category": ["Overworld", "Poe", "Arbiters Grounds"],
+    "category": ["Dungeon", "Poe", "Arbiters Grounds"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds Hidden Wall Poe.jsonc
+++ b/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds Hidden Wall Poe.jsonc
@@ -2,6 +2,6 @@
   "requirements": "Shadow_Crystal and CanDefeatRedeadKnight and ((Arbiters_Grounds_Small_Key, 3) or (Setting.smallKeySettings equals Keysy))",
   "stageIDX": [ 24 ],
   "flag": "20",
-  "category": [ "Overworld", "Poe", "Arbiters Grounds" ],
+  "category": [ "Dungeon", "Poe", "Arbiters Grounds" ],
   "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds Torch Room Poe.jsonc
+++ b/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds Torch Room Poe.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal",
     "stageIDX": [24],
     "flag": "1E",
-    "category": ["Overworld", "Poe", "Arbiters Grounds"],
+    "category": ["Dungeon", "Poe", "Arbiters Grounds"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds West Poe.jsonc
+++ b/Generator/World/Checks/Dungeons/Arbiters Grounds/Arbiters Grounds West Poe.jsonc
@@ -2,6 +2,6 @@
   "requirements": "Shadow_Crystal and canSmash and ((Arbiters_Grounds_Small_Key, 4) or (Setting.smallKeySettings equals Keysy)) and CanDefeatRedeadKnight and CanDefeatStalchild and CanDefeatBubble and CanDefeatGhoulRat",
   "stageIDX": [ 24 ],
   "flag": "21",
-  "category": [ "Overworld", "Poe", "Arbiters Grounds" ],
+  "category": [ "Dungeon", "Poe", "Arbiters Grounds" ],
   "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Dungeons/City in The Sky/City in The Sky Garden Island Poe.jsonc
+++ b/Generator/World/Checks/Dungeons/City in The Sky/City in The Sky Garden Island Poe.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal and (Progressive_Clawshot, 2)",
     "stageIDX": [12],
     "flag": "54",
-    "category": ["Overworld", "Poe", "City in The Sky"],
+    "category": ["Dungeon", "Poe", "City in The Sky"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Dungeons/City in The Sky/City in The Sky Poe Above Central Fan.jsonc
+++ b/Generator/World/Checks/Dungeons/City in The Sky/City in The Sky Poe Above Central Fan.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal and CanDefeatWalltula",
     "stageIDX": [12],
     "flag": "55",
-    "category": ["Overworld", "Poe", "City in The Sky"],
+    "category": ["Dungeon", "Poe", "City in The Sky"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Ice Room Poe.jsonc
+++ b/Generator/World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Ice Room Poe.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal",
     "stageIDX": [27],
     "flag": "7F",
-    "category": ["Overworld", "Poe", "Snowpeak Ruins"],
+    "category": ["Dungeon", "Poe", "Snowpeak Ruins"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Lobby Armor Poe.jsonc
+++ b/Generator/World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Lobby Armor Poe.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal and Ball_and_Chain",
     "stageIDX": [27],
     "flag": "15",
-    "category": ["Overworld", "Poe", "Snowpeak Ruins"],
+    "category": ["Dungeon", "Poe", "Snowpeak Ruins"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Lobby Poe.jsonc
+++ b/Generator/World/Checks/Dungeons/Snowpeak Ruins/Snowpeak Ruins Lobby Poe.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal",
     "stageIDX": [27],
     "flag": "72",
-    "category": ["Overworld", "Poe", "Snowpeak Ruins"],
+    "category": ["Dungeon", "Poe", "Snowpeak Ruins"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Dungeons/Temple of Time/Temple of Time Poe Above Scales.jsonc
+++ b/Generator/World/Checks/Dungeons/Temple of Time/Temple of Time Poe Above Scales.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal and (Progressive_Clawshot, 1) and Spinner",
     "stageIDX": [9],
     "flag": "18",
-    "category": ["Overworld", "Poe", "Temple of Time"],
+    "category": ["Dungeon", "Poe", "Temple of Time"],
     "itemId": "Poe_Soul"
 }

--- a/Generator/World/Checks/Dungeons/Temple of Time/Temple of Time Poe Behind Gate.jsonc
+++ b/Generator/World/Checks/Dungeons/Temple of Time/Temple of Time Poe Behind Gate.jsonc
@@ -2,6 +2,6 @@
     "requirements": "Shadow_Crystal and (Progressive_Dominion_Rod, 1)",
     "stageIDX": [9],
     "flag": "19",
-    "category": ["Overworld", "Poe", "Temple of Time"],
+    "category": ["Dungeon", "Poe", "Temple of Time"],
     "itemId": "Poe_Soul"
 }

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -223,13 +223,6 @@
               </div>
               <div
                 style="width: 50%"
-                data-tooltip-text="If checked, the souls recieved from Poes will be randomized.&#0010;"
-              >
-                <input type="checkbox" id="poesCheckbox" name="Poes" value="" />
-                <label for="poesCheckbox"> Poes </label><br />
-              </div>
-              <div
-                style="width: 50%"
                 data-tooltip-text="If checked, the items you can permanently buy from shops are randomized.&#0010;"
               >
                 <input
@@ -251,6 +244,19 @@
                   value=""
                 />
                 <label for="hiddenSkillsCheckbox"> Hidden Skills </label><br />
+              </div>
+              <div class="selectGroup">
+                <label for="poeSettingsFieldset">Poe Souls:</label><br />
+                <select
+                  name="Poe Soul Settings"
+                  data-tooltip-text="'Vanilla': Poe Souls will not be randomized.&#0010;&#0010;'Overworld': Only Poes in the Overworld will have their souls shuffled.&#0010;&#0010;'Dungeon': Only Poes in Dungeons will have their souls shuffled.&#0010;&#0010;'All': All Poes will have their souls shuffled.&#0010;"
+                  id="poeSettingsFieldset"
+                >
+                  <option value="0" selected>Vanilla</option>
+                  <option value="1">Overworld</option>
+                  <option value="2">Dungeons</option>
+                  <option value="3">All</option>
+                </select>
               </div>
               <div class="selectGroup" style="margin-top: 8px">
                 <label for="itemScarcityFieldset">Item Scarcity</label><br />

--- a/packages/client/js/shared.js
+++ b/packages/client/js/shared.js
@@ -347,7 +347,7 @@
       { id: 'goldenBugsCheckbox' },
       { id: 'skyCharacterCheckbox' },
       { id: 'giftsFromNPCsCheckbox' },
-      { id: 'poesCheckbox' },
+      { id: 'poeSettingsFieldset', bitLength: 2 },
       { id: 'shopItemsCheckbox' },
       { id: 'hiddenSkillsCheckbox' },
       { id: 'smallKeyFieldset', bitLength: 3 },
@@ -706,7 +706,21 @@
     processBasic({ id: 'goldenBugs' });
     processBasic({ id: 'skyCharacters' });
     processBasic({ id: 'giftsFromNpcs' });
-    processBasic({ id: 'poes' });
+    if (version >= 4) {
+      // `poes` changed from a checkbox to a select
+      processBasic({ id: 'poes', bitLength: 2 });
+    } else {
+      const poeSettings = {
+        vanilla: 0,
+        overworld: 1,
+        dungeons: 2,
+        all: 3
+      };
+      const shufflePoes = processor.nextBoolean();
+      res.poes = shufflePoes
+        ? poeSettings.overworld
+        : poeSettings.vanilla;
+    }
     processBasic({ id: 'shopItems' });
     processBasic({ id: 'hiddenSkills' });
     processBasic({ id: 'smallKeys', bitLength: 3 });

--- a/packages/client/script.js
+++ b/packages/client/script.js
@@ -241,9 +241,7 @@ document
 document
   .getElementById('giftsFromNPCsCheckbox')
   .addEventListener('click', setSettingsString);
-document
-  .getElementById('poesCheckbox')
-  .addEventListener('click', setSettingsString);
+document.getElementById('poeSettingsFieldset').onchange = setSettingsString;
 document
   .getElementById('shopItemsCheckbox')
   .addEventListener('click', setSettingsString);
@@ -342,7 +340,7 @@ function setSettingsString() {
     'mapAndCompassFieldset'
   ).selectedIndex;
   settingsStringRaw[9] = document.getElementById('goldenBugsCheckbox').checked;
-  settingsStringRaw[10] = document.getElementById('poesCheckbox').checked;
+  settingsStringRaw[10] = document.getElementById('poeSettingsFieldset').selectedIndex;
   settingsStringRaw[11] = document.getElementById(
     'giftsFromNPCsCheckbox'
   ).checked;
@@ -567,7 +565,7 @@ var arrayOfSettingsItems = [
   'bigKeyFieldset',
   'mapAndCompassFieldset',
   'goldenBugsCheckbox',
-  'poesCheckbox',
+  'poeSettingsFieldset',
   'giftsFromNPCsCheckbox',
   'shopItemsCheckbox',
   'faronTwilightCheckbox',
@@ -1118,7 +1116,7 @@ function populateSSettings(s) {
   $('#goldenBugsCheckbox').prop('checked', s.goldenBugs);
   $('#skyCharacterCheckbox').prop('checked', s.skyCharacters);
   $('#giftsFromNPCsCheckbox').prop('checked', s.giftsFromNpcs);
-  $('#poesCheckbox').prop('checked', s.poes);
+  $('#poeSettingsFieldset').val(s.poes);
   $('#shopItemsCheckbox').prop('checked', s.shopItems);
   $('#hiddenSkillsCheckbox').prop('checked', s.hiddenSkills);
   $('#smallKeyFieldset').val(s.smallKeys);


### PR DESCRIPTION
Changes the shuffle poes checkbox to be a drop down with multiple options for more variety. Below are the options:

- Vanilla:
- - No poe souls are shuffled
- Overworld
- - Only Overworld poes are shuffled
- Dungeon
- - Only Dungeon poes are shuffled
- All
- - All poes are shuffled