### PR TITLE
Use no endColors on link house sign so text fits

### DIFF
--- a/Generator/Logic/CustomMsgData.cs
+++ b/Generator/Logic/CustomMsgData.cs
@@ -654,7 +654,9 @@ namespace TPRandomizer
                 {
                     if (sb.Length > 0)
                         sb.Append('\n');
-                    sb.Append(Res.Msg(tuple.Item1, null).ResolveWithColor(tuple.Item3));
+                    // Use an empty string for the end color so we do not run
+                    // out of bytes and have the text get cut off.
+                    sb.Append(Res.Msg(tuple.Item1, null).ResolveWithColor(tuple.Item3, ""));
                 }
             }
 

--- a/Generator/Translations/Res.cs
+++ b/Generator/Translations/Res.cs
@@ -1364,7 +1364,8 @@ namespace TPRandomizer
 
             public string ResolveWithColor(string startColor, string endColor = null)
             {
-                if (StringUtils.isEmpty(endColor))
+                // Allow passing an empty string in to avoid adding an endColor.
+                if (endColor == null)
                     endColor = CustomMessages.messageColorWhite;
 
                 if (value.Contains("{cs}"))


### PR DESCRIPTION
- Use no endColors on link house sign so text fits