### PR TITLE
Cache parse trees for logic expressions

### DIFF
--- a/Generator/Assets/Checks.cs
+++ b/Generator/Assets/Checks.cs
@@ -62,7 +62,7 @@ namespace TPRandomizer
                 return reqsCache;
             }
 
-            return reqsCache = Parser2.Parse(requirements);
+            return reqsCache = Parser.Parse(requirements);
         }
     }
 

--- a/Generator/Assets/Checks.cs
+++ b/Generator/Assets/Checks.cs
@@ -55,6 +55,15 @@ namespace TPRandomizer
         public List<string> overrideInstruction { get; set; } // Used by REL checks. The override instruction to be used when replacing the item in the rel.
 
         public bool isRequired { get; set; }
+
+        private LogicAST reqsCache;
+        public LogicAST CachedRequirements() {
+            if(reqsCache != null) {
+                return reqsCache;
+            }
+
+            return reqsCache = Parser2.Parse(requirements);
+        }
     }
 
     /// <summary>

--- a/Generator/Assets/Entrances/EntranceRando.cs
+++ b/Generator/Assets/Entrances/EntranceRando.cs
@@ -85,7 +85,7 @@ namespace TPRandomizer
                 return reqsCache;
             }
 
-            return reqsCache = Parser2.Parse(Requirements);
+            return reqsCache = Parser.Parse(Requirements);
         }
 
         public int GetStage()

--- a/Generator/Assets/Entrances/EntranceRando.cs
+++ b/Generator/Assets/Entrances/EntranceRando.cs
@@ -79,6 +79,15 @@ namespace TPRandomizer
         public bool AlreadySetOriginalName { get; set; }
         public string PairedEntranceName { get; set; } = "";
 
+        private LogicAST reqsCache;
+        public LogicAST CachedRequirements() {
+            if(reqsCache != null) {
+                return reqsCache;
+            }
+
+            return reqsCache = Parser2.Parse(Requirements);
+        }
+
         public int GetStage()
         {
             return Stage;

--- a/Generator/Glitched-World/Rooms/Overworld/Faron Province/Hyrule Field - Faron.jsonc
+++ b/Generator/Glitched-World/Rooms/Overworld/Faron Province/Hyrule Field - Faron.jsonc
@@ -44,7 +44,7 @@
       [
         {
           "ConnectedArea": "Faron Field",
-          "Requirements": "Room.Lower_Kakariko_Village  HasBottle and Room.Outside_Castle_Town_South"
+          "Requirements": "Room.Lower_Kakariko_Village and HasBottle and Room.Outside_Castle_Town_South"
         },
         {
            // If you enter Outside Castle Town from there while the boulder is still there, you get stuck and are forced to save-warp or portal-warp.

--- a/Generator/Logic/BackendFunctions.cs
+++ b/Generator/Logic/BackendFunctions.cs
@@ -78,11 +78,7 @@ namespace TPRandomizer
 
                         if (!currentCheck.hasBeenReached)
                         {
-                            var areCheckRequirementsMet = Randomizer.Logic.EvaluateRequirements(
-                                currentCheck.checkName,
-                                currentCheck.requirements
-                            );
-                            if ((bool)areCheckRequirementsMet == true)
+                            if (currentCheck.CachedRequirements().Evaluate())
                             {
                                 if (currentCheck.itemWasPlaced)
                                 {
@@ -289,11 +285,7 @@ namespace TPRandomizer
 
                         if (!currentCheck.hasBeenReached)
                         {
-                            var areCheckRequirementsMet = Randomizer.Logic.EvaluateRequirements(
-                                currentCheck.checkName,
-                                currentCheck.requirements
-                            );
-                            if ((bool)areCheckRequirementsMet == true)
+                            if (currentCheck.CachedRequirements().Evaluate())
                             {
                                 sphereItems.Add(currentCheck.itemId);
                                 currentCheck.hasBeenReached = true;
@@ -463,11 +455,7 @@ namespace TPRandomizer
 
                         if (!currentCheck.hasBeenReached)
                         {
-                            var areCheckRequirementsMet = Randomizer.Logic.EvaluateRequirements(
-                                currentCheck.checkName,
-                                currentCheck.requirements
-                            );
-                            if ((bool)areCheckRequirementsMet == true)
+                            if (currentCheck.CachedRequirements().Evaluate())
                             {
                                 playthroughDictionaryAll.Add(
                                     "    " + currentCheck.checkName + ": " + currentCheck.itemId,
@@ -668,11 +656,7 @@ namespace TPRandomizer
 
                             if (!currentCheck.hasBeenReached && currentCheck.itemWasPlaced)
                             {
-                                var areCheckRequirementsMet = Randomizer.Logic.EvaluateRequirements(
-                                    currentCheck.checkName,
-                                    currentCheck.requirements
-                                );
-                                if ((bool)areCheckRequirementsMet == true)
+                                if (currentCheck.CachedRequirements().Evaluate())
                                 {
                                     currentCheck.hasBeenReached = true;
                                     if (
@@ -832,11 +816,7 @@ namespace TPRandomizer
 
                             if (!currentCheck.hasBeenReached && currentCheck.itemWasPlaced)
                             {
-                                var areCheckRequirementsMet = Randomizer.Logic.EvaluateRequirements(
-                                    currentCheck.checkName,
-                                    currentCheck.requirements
-                                );
-                                if ((bool)areCheckRequirementsMet == true)
+                                if (currentCheck.CachedRequirements().Evaluate())
                                 {
                                     currentCheck.hasBeenReached = true;
                                     if (
@@ -985,11 +965,7 @@ namespace TPRandomizer
                                 && currentCheck.isRequired
                             )
                             {
-                                var areCheckRequirementsMet = Randomizer.Logic.EvaluateRequirements(
-                                    currentCheck.checkName,
-                                    currentCheck.requirements
-                                );
-                                if ((bool)areCheckRequirementsMet == true)
+                                if (currentCheck.CachedRequirements().Evaluate())
                                 {
                                     currentCheck.hasBeenReached = true;
 

--- a/Generator/Logic/LogicFunctions.cs
+++ b/Generator/Logic/LogicFunctions.cs
@@ -10,11 +10,6 @@ namespace TPRandomizer
     /// </summary>
     public class LogicFunctions
     {
-        /// <summary>
-        /// summary text.
-        /// </summary>
-        public Dictionary<Token, string> TokenDict = new();
-
         //Evaluate the tokenized settings to their respective values that are set by the settings string.
 
         /// <summary>

--- a/Generator/Logic/LogicFunctions.cs
+++ b/Generator/Logic/LogicFunctions.cs
@@ -2331,18 +2331,5 @@ namespace TPRandomizer
             }
             return isQuantity;
         }
-
-        /// <summary>
-        /// summary text.
-        /// </summary>
-        public bool EvaluateRequirements(string location, string expression)
-        {
-            Parser parse = new Parser();
-            parse.ParserReset();
-            Randomizer.Logic.TokenDict = new Tokenizer(expression).Tokenize();
-            parse.checkedLogicItem = location + " with logic: " + expression;
-            //Console.WriteLine(parse.checkedLogicItem);
-            return parse.Parse();
-        }
     }
 }

--- a/Generator/Logic/LogicTokenizer.cs
+++ b/Generator/Logic/LogicTokenizer.cs
@@ -5,454 +5,23 @@ using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 
+#nullable enable
 namespace TPRandomizer
 {
-    // Expression         := [ "!" ] <Boolean> { <BooleanOperator> <Boolean> } ...
-    // Boolean            := <BooleanConstant> | <Expression> | "(" <Expression> ")"
-    // BooleanOperator    := "And" | "Or"
-    // BooleanConstant    := "True" | "False"
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class Parser
-    {
-        public int tokenValue;
-        public int isinParenthesis = 0;
-        public string checkedLogicItem;
-
-        /// <summary>
-        /// summary text.
-        /// </summary>
-        public void ParserReset()
-        {
-            tokenValue = 0;
-            Randomizer.Logic.TokenDict.Clear();
-        }
-
-        /// <summary>
-        /// summary text.
-        /// </summary>
-        public bool Parse()
-        {
-            while (
-                Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key != null
-                && !(tokenValue > Randomizer.Logic.TokenDict.Count() - 1)
-            )
-            {
-                var boolean = ParseBoolean();
-                while (
-                    (tokenValue <= Randomizer.Logic.TokenDict.Count() - 1)
-                    && Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key is OperandToken
-                )
-                {
-                    var operand = Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key;
-                    tokenValue++;
-                    var nextBoolean = ParseBoolean();
-                    if (operand is AndToken)
-                        boolean = boolean && nextBoolean;
-                    else
-                        boolean = boolean || nextBoolean;
-                }
-
-                // If the code makes it to this point, it is catching the closing parenthesis. If there shouldn't be one at this point, we want to parse and account for it.
-                if (
-                    (isinParenthesis == 0) && !(tokenValue > Randomizer.Logic.TokenDict.Count() - 1)
-                )
-                {
-                    ParseBoolean();
-                }
-                return boolean;
-            }
-
-            throw new Exception("Empty expression");
-        }
-
-        /// <summary>
-        /// summary text.
-        /// </summary>
-        private bool ParseBoolean()
-        {
-            var parseBool = false;
-            if (Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key is BooleanValueToken)
-            {
-                var current = Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key;
-                tokenValue++;
-
-                if (current is TrueToken)
-                    return true;
-
-                return false;
-            }
-            else if (Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key is OpenParenthesisToken)
-            {
-                isinParenthesis++;
-                tokenValue++;
-
-                var expInPars = Parse();
-
-                // If there are no more characters and we have a hanging open parenthesis, throw an error
-                if (
-                    !(
-                        Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key
-                        is ClosedParenthesisToken
-                    )
-                )
-                {
-                    for (int i = tokenValue; i < Randomizer.Logic.TokenDict.Count(); i++)
-                    {
-                        Console.WriteLine(
-                            "Stack Trace: " + Randomizer.Logic.TokenDict.ElementAt(i).Value
-                        );
-                    }
-                    throw new Exception(
-                        "Expecting Closing Parenthesis but got: "
-                            + Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key
-                            + ": "
-                            + Randomizer.Logic.TokenDict.ElementAt(tokenValue).Value
-                            + " at index: "
-                            + tokenValue
-                    );
-                }
-
-                tokenValue++;
-                isinParenthesis -= 1;
-
-                return expInPars;
-            }
-            else if (
-                Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key is ClosedParenthesisToken
-                && (isinParenthesis == 0)
-            )
-            {
-                throw new Exception(
-                    "Unexpected Closed Parenthesis in location: " + checkedLogicItem
-                );
-            }
-            else if (Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key is itemToken)
-            {
-                string evaluatedItem = Randomizer.Logic.TokenDict.ElementAt(tokenValue).Value;
-                tokenValue++;
-                if ((Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key is CommaToken))
-                {
-                    tokenValue++;
-                    parseBool = LogicFunctions.verifyItemQuantity(
-                        evaluatedItem,
-                        Int16.Parse(Randomizer.Logic.TokenDict.ElementAt(tokenValue).Value)
-                    );
-                    tokenValue++;
-                }
-                else
-                {
-                    parseBool = LogicFunctions.CanUse(evaluatedItem);
-                }
-                return parseBool;
-            }
-            else if (Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key is logicFunctionToken)
-            {
-                string evaluatedFunction = Randomizer.Logic.TokenDict.ElementAt(tokenValue).Value;
-                tokenValue++;
-                // If a comma follows a function, we assume it is needing to be compared to an integer
-                if (Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key is CommaToken)
-                {
-                    tokenValue++;
-                    int getQuantity = 0;
-                    getQuantity = (int)
-                        typeof(LogicFunctions).GetMethod(evaluatedFunction).Invoke(this, null);
-                    if (
-                        getQuantity
-                        >= Int16.Parse(Randomizer.Logic.TokenDict.ElementAt(tokenValue).Value)
-                    )
-                    {
-                        parseBool = true;
-                    }
-                    tokenValue++;
-                }
-                // If there is no comma following the function, then it doesnt need to return an int value, and we can continue to evaluate it
-                else
-                {
-                    parseBool = (bool)
-                        typeof(LogicFunctions).GetMethod(evaluatedFunction).Invoke(this, null);
-                }
-                return parseBool;
-            }
-            else if (Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key is settingsToken)
-            {
-                string evaluatedItem = Randomizer.Logic.TokenDict.ElementAt(tokenValue).Value;
-                tokenValue++;
-                if (Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key is EqualsToken)
-                {
-                    tokenValue++;
-                    parseBool = LogicFunctions.EvaluateSetting(
-                        evaluatedItem,
-                        Randomizer.Logic.TokenDict.ElementAt(tokenValue).Value.ToString()
-                    );
-                    tokenValue++;
-                }
-                else if (Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key is NegationToken)
-                {
-                    tokenValue++;
-                    parseBool = !LogicFunctions.EvaluateSetting(
-                        evaluatedItem,
-                        Randomizer.Logic.TokenDict.ElementAt(tokenValue).Value.ToString()
-                    );
-                    tokenValue++;
-                }
-                return parseBool;
-            }
-            else if (Randomizer.Logic.TokenDict.ElementAt(tokenValue).Key is roomToken)
-            {
-                string evaluatedToken = Randomizer.Logic.TokenDict.ElementAt(tokenValue).Value;
-                string roomName = evaluatedToken.Replace("Room.", string.Empty);
-                roomName = roomName.Replace("_", " ");
-                tokenValue++;
-                parseBool = Randomizer.Rooms.RoomDict[roomName].ReachedByPlaythrough;
-                return parseBool;
-            }
-
-            // since its not a BooleanConstant or Expression in parenthesis, it must be a expression again
-            var val = Parse();
-            return val;
-        }
-    }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class Tokenizer
-    {
-        private char[] _reader;
-        private string _text;
-
-        public Tokenizer(string text)
-        {
-            _text = text;
-            _reader = text.ToCharArray();
-        }
-
-        /// <summary>
-        /// summary text.
-        /// </summary>
-        public Dictionary<Token, string> Tokenize()
-        {
-            Dictionary<Token, string> tokens = new Dictionary<Token, String>();
-            int i = 0;
-            while (i < _reader.Length)
-            {
-                while (Char.IsWhiteSpace((char)_reader[i]))
-                {
-                    i++;
-                }
-
-                switch (_reader[i])
-                {
-                    case '!':
-                        tokens.Add(new NegationToken(), _reader[i].ToString());
-                        i++;
-                        break;
-                    case '(':
-                        tokens.Add(new OpenParenthesisToken(), _reader[i].ToString());
-                        i++;
-                        break;
-                    case ')':
-                        tokens.Add(new ClosedParenthesisToken(), _reader[i].ToString());
-                        i++;
-                        break;
-                    case ',':
-                        tokens.Add(new CommaToken(), _reader[i].ToString());
-                        i++;
-                        break;
-                    default:
-                        var text = new StringBuilder();
-                        if (Char.IsLetter(_reader[i]))
-                        {
-                            while (
-                                Char.IsLetter(_reader[i])
-                                || (_reader[i] == '_')
-                                || (_reader[i] == '.')
-                            )
-                            {
-                                text.Append(_reader[i]);
-                                i++;
-                            }
-
-                            var potentialKeyword = text.ToString();
-
-                            switch (potentialKeyword)
-                            {
-                                case "true":
-                                    tokens.Add(new TrueToken(), potentialKeyword.ToString());
-                                    break;
-                                case "false":
-                                    tokens.Add(new FalseToken(), potentialKeyword.ToString());
-                                    break;
-                                case "and":
-                                    tokens.Add(new AndToken(), potentialKeyword.ToString());
-                                    break;
-                                case "or":
-                                    tokens.Add(new OrToken(), potentialKeyword.ToString());
-                                    break;
-                                case "equals":
-                                    tokens.Add(new EqualsToken(), potentialKeyword.ToString());
-                                    break;
-                                case "not_equal":
-                                    tokens.Add(new NegationToken(), potentialKeyword.ToString());
-                                    break;
-                                default:
-                                    if (Enum.IsDefined(typeof(Item), potentialKeyword))
-                                    {
-                                        tokens.Add(new itemToken(), potentialKeyword.ToString());
-                                        break;
-                                    }
-                                    // if it is a setting, it needs to be evaluated as such later on
-                                    else if (potentialKeyword.Contains("Setting."))
-                                    {
-                                        tokens.Add(
-                                            new settingsToken(),
-                                            potentialKeyword.ToString()
-                                        );
-                                        break;
-                                    }
-                                    else if (potentialKeyword.Contains("Room."))
-                                    {
-                                        tokens.Add(new roomToken(), potentialKeyword.ToString());
-                                        break;
-                                    }
-                                    // If it isnt a keyword, we assume that it is a logic function
-                                    else
-                                    {
-                                        tokens.Add(
-                                            new logicFunctionToken(),
-                                            potentialKeyword.ToString()
-                                        );
-                                        break;
-                                    }
-                            }
-                        }
-                        // If the char is an integer, we need to see if it is a larger number (one that is more than one char)
-                        else if (Char.IsNumber(_reader[i]))
-                        {
-                            var num = new StringBuilder();
-                            while (Char.IsNumber(_reader[i]))
-                            {
-                                num.Append(_reader[i]);
-                                i++;
-                            }
-                            tokens.Add(new IntegerToken(), num.ToString());
-                        }
-                        else
-                        {
-                            var remainingText = new string(_reader) ?? string.Empty;
-                            throw new Exception(string.Format("Unknown Grammar: " + remainingText));
-                        }
-                        break;
-                }
-            }
-            return tokens;
-        }
-    }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class OperandToken : Token { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class OrToken : OperandToken { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class AndToken : OperandToken { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class BooleanValueToken : Token { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class logicFunctionToken : Token { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class IntegerToken : Token { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class itemToken : Token { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class FalseToken : BooleanValueToken { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class TrueToken : BooleanValueToken { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class ParenthesisToken : Token { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class EqualsToken : OperandToken { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class settingsToken : OperandToken { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class roomToken : OperandToken { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class CommaToken : Token { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class canUseToken : Token { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class ClosedParenthesisToken : ParenthesisToken { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class OpenParenthesisToken : ParenthesisToken { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public class NegationToken : Token { }
-
-    /// <summary>
-    /// summary text.
-    /// </summary>
-    public abstract class Token { }
+    // Expression         := <Boolean> { <BooleanOperator> <Boolean> } ...
+    // Boolean            := <BooleanConstant> | <ItemOrFunction> | <ProgressiveItem> | <Room> | <Setting> | "(" <Expression> ")"
+    // BooleanOperator    := "and" | "or"
+    // BooleanConstant    := "true" | "false"
+    // ItemOrFunction     := <Name>
+    // Room               := Room.<Name>
+    // Setting            := "(" <Name> { "equals" | "not_equal" } <Value> ")"
+    // ProgressiveItem    := "(" <Name> "," <Count> ")"
 
     public abstract class LogicAST
     {
         public abstract bool Evaluate();
     }
 
-#nullable enable
     namespace AST
     {
         public class True : LogicAST
@@ -549,7 +118,7 @@ namespace TPRandomizer
         }
     }
 
-    public class Parser2
+    public class Parser
     {
         static Regex progressiveItemRegex = new(@"^\((\w+\s*),\s*(\d+)\)");
         static Regex settingRegex = new(@"^\(Setting.(\w+)\s+equals\s+(\w+)\)");
@@ -570,7 +139,14 @@ namespace TPRandomizer
             }
 
             string exprClone = expression;
-            LogicAST parsed = parseInner(ref exprClone);
+            LogicAST parsed;
+            try {
+                parsed = parseInner(ref exprClone);
+            } catch(Exception e) {
+                Console.WriteLine($"Failed to parse logic expression {expression}: {e}");
+                throw;
+            }
+
             parseCache[expression] = parsed;
             return parsed;
         }
@@ -610,6 +186,9 @@ namespace TPRandomizer
                     expression = expression[1..];
                     thisNode = parseInner(ref expression);
                     // skip the final )
+                    if(expression.Length == 0 || expression[0] != ')') {
+                        throw new Exception("Expected closing parenthesis");
+                    }
                     expression = expression[1..];
                 }
                 else if (Re(trueRegex, ref expression) != null)

--- a/Generator/Logic/LogicTokenizer.cs
+++ b/Generator/Logic/LogicTokenizer.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace TPRandomizer
 {
@@ -444,4 +446,230 @@ namespace TPRandomizer
     /// summary text.
     /// </summary>
     public abstract class Token { }
+
+    public abstract class LogicAST
+    {
+        public abstract bool Evaluate();
+    }
+
+#nullable enable
+    namespace AST
+    {
+        public class True : LogicAST
+        {
+            public override bool Evaluate() => true;
+        }
+
+        public class False : LogicAST
+        {
+            public override bool Evaluate() => false;
+        }
+
+        public class Function : LogicAST
+        {
+            string FunctionName { get; }
+
+            public Function(string function) => FunctionName = function;
+
+            public override bool Evaluate()
+            {
+                MethodInfo? method = typeof(LogicFunctions).GetMethod(FunctionName);
+                if (method == null)
+                {
+                    Console.WriteLine($"unknown logic function {FunctionName}");
+                    return false;
+                }
+
+                object? result = method.Invoke(null, null);
+                if (result is bool resultBool)
+                {
+                    return resultBool;
+                }
+                else
+                {
+                    Console.WriteLine($"logic function {FunctionName} returned non-bool {result}");
+                    return false;
+                }
+            }
+        }
+
+        public class Item : LogicAST
+        {
+            TPRandomizer.Item ItemId { get; }
+            int Count { get; }
+
+            public Item(TPRandomizer.Item item, int count) => (ItemId, Count) = (item, count);
+
+            public override bool Evaluate()
+            {
+                int heldCount = Randomizer.Items.heldItems.Where(i => i == ItemId).Count();
+                // Console.WriteLine($"Item.Evaluate {heldCount} {Count} {ItemId}");
+                return heldCount >= Count;
+            }
+        }
+
+        public class Room : LogicAST
+        {
+            string RoomName { get; }
+
+            public Room(string room) => RoomName = room;
+
+            public override bool Evaluate() => Randomizer.Rooms.RoomDict[RoomName].ReachedByPlaythrough;
+        }
+
+        public class Setting : LogicAST
+        {
+            string SettingName { get; }
+            string SettingValue { get; }
+            bool Sense { get; }
+
+            public Setting(string setting, string value, bool sense) => (SettingName, SettingValue, Sense) = (setting, value, sense);
+
+            public override bool Evaluate() => LogicFunctions.EvaluateSetting(SettingName, SettingValue) == Sense;
+        }
+
+        public class Conjunction : LogicAST
+        {
+            LogicAST Left { get; }
+            LogicAST Right { get; }
+
+            public Conjunction(LogicAST left, LogicAST right) => (Left, Right) = (left, right);
+
+            public override bool Evaluate() => Left.Evaluate() && Right.Evaluate();
+        }
+
+        public class Disjunction : LogicAST
+        {
+            LogicAST Left { get; }
+            LogicAST Right { get; }
+
+            public Disjunction(LogicAST left, LogicAST right) => (Left, Right) = (left, right);
+
+            public override bool Evaluate() => Left.Evaluate() || Right.Evaluate();
+        }
+    }
+
+    public class Parser2
+    {
+        static Regex progressiveItemRegex = new(@"^\((\w+\s*),\s*(\d+)\)");
+        static Regex settingRegex = new(@"^\(Setting.(\w+)\s+equals\s+(\w+)\)");
+        static Regex settingInverseRegex = new(@"^\(Setting.(\w+)\s+not_equal\s+(\w+)\)");
+        static Regex roomRegex = new(@"^Room.(\w+)");
+        static Regex trueRegex = new(@"^true");
+        static Regex falseRegex = new(@"^false");
+        static Regex itemOrFunctionRegex = new(@"^(\w+)");
+        static Regex conjunctionRegex = new(@"^and\s+");
+        static Regex disjunctionRegex = new(@"^or\s+");
+        static Dictionary<string, LogicAST> parseCache = [];
+
+        public static LogicAST Parse(string expression)
+        {
+            if (parseCache.TryGetValue(expression, out LogicAST? value))
+            {
+                return value;
+            }
+
+            string exprClone = expression;
+            LogicAST parsed = parseInner(ref exprClone);
+            parseCache[expression] = parsed;
+            return parsed;
+        }
+
+        static LogicAST parseInner(ref string expression)
+        {
+            // Console.WriteLine($" parse {expression}");
+            LogicAST? tree = null;
+
+            while (expression.Length > 0)
+            {
+                expression = expression.Trim();
+                // Console.WriteLine($" parse iterate {expression} {tree}");
+                Match? m;
+                LogicAST thisNode;
+
+                if ((m = Re(progressiveItemRegex, ref expression)) != null)
+                {
+                    thisNode = new AST.Item(Enum.Parse<Item>(m.Groups[1].Value), int.Parse(m.Groups[2].Value));
+                }
+                else if ((m = Re(settingRegex, ref expression)) != null)
+                {
+                    thisNode = new AST.Setting(m.Groups[1].Value, m.Groups[2].Value, true);
+                }
+                else if ((m = Re(settingInverseRegex, ref expression)) != null)
+                {
+                    thisNode = new AST.Setting(m.Groups[1].Value, m.Groups[2].Value, false);
+                }
+                else if ((m = Re(roomRegex, ref expression)) != null)
+                {
+                    thisNode = new AST.Room(m.Groups[1].Value.Replace('_', ' '));
+                }
+                else if (expression.StartsWith('('))
+                {
+                    // Start of a subexpression. We know it's not a progressive item check because
+                    // we looked for that earlier.
+                    expression = expression[1..];
+                    thisNode = parseInner(ref expression);
+                    // skip the final )
+                    expression = expression[1..];
+                }
+                else if (Re(trueRegex, ref expression) != null)
+                {
+                    thisNode = new AST.True();
+                }
+                else if (Re(falseRegex, ref expression) != null)
+                {
+                    thisNode = new AST.False();
+                }
+                else if (Re(conjunctionRegex, ref expression) != null)
+                {
+                    thisNode = new AST.Conjunction(tree!, parseInner(ref expression));
+                }
+                else if (Re(disjunctionRegex, ref expression) != null)
+                {
+                    thisNode = new AST.Disjunction(tree!, parseInner(ref expression));
+                }
+                else if ((m = Re(itemOrFunctionRegex, ref expression)) != null)
+                {
+                    if (Enum.TryParse(m.Groups[1].Value, out Item item))
+                    {
+                        thisNode = new AST.Item(item, 1);
+                    }
+                    else
+                    {
+                        thisNode = new AST.Function(m.Groups[1].Value);
+                    }
+                }
+                else if (expression.StartsWith(')'))
+                {
+                    // end of a subexpression. let the caller handle advancing the read pointeru
+                    break;
+                }
+                else
+                {
+                    Console.WriteLine($"failed to parse remainder of logic expression: {expression}");
+                    expression = "";
+                    thisNode = new AST.False();
+                }
+
+                tree = thisNode;
+            }
+
+            return tree!;
+        }
+
+        // helper function to match or return null for comparison chains
+        static Match? Re(Regex source, ref string expression)
+        {
+            Match m = source.Match(expression);
+            if (m.Success)
+            {
+                expression = expression[m.Length..];
+                return m;
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
 }

--- a/Generator/Logic/LogicTokenizer.cs
+++ b/Generator/Logic/LogicTokenizer.cs
@@ -148,9 +148,12 @@ namespace TPRandomizer
 
             string exprClone = expression;
             LogicAST parsed;
-            try {
-                parsed = ParseInner(ref exprClone);
-            } catch(Exception e) {
+            try
+            {
+                parsed = ParseInner(ref exprClone, 0);
+            }
+            catch (Exception e)
+            {
                 Console.WriteLine($"Failed to parse logic expression {expression}: {e}");
                 throw;
             }
@@ -164,7 +167,7 @@ namespace TPRandomizer
         // one reference to expression and substring it as we consume characters.
         //
         // you could also do this with a pointer that gets passed to Match but it's more boilerplate
-        static LogicAST ParseInner(ref string expression)
+        static LogicAST ParseInner(ref string expression, int depth)
         {
             LogicAST? tree = null;
 
@@ -195,9 +198,10 @@ namespace TPRandomizer
                     // Start of a subexpression. We know it's not a progressive item check because
                     // we looked for that earlier.
                     expression = expression[1..];
-                    thisNode = ParseInner(ref expression);
+                    thisNode = ParseInner(ref expression, depth + 1);
                     // skip the final )
-                    if(expression.Length == 0 || expression[0] != ')') {
+                    if (expression.Length == 0 || expression[0] != ')')
+                    {
                         throw new Exception("Expected closing parenthesis");
                     }
                     expression = expression[1..];
@@ -212,11 +216,11 @@ namespace TPRandomizer
                 }
                 else if (Re(conjunctionRegex, ref expression) != null)
                 {
-                    thisNode = new AST.Conjunction(tree!, ParseInner(ref expression));
+                    thisNode = new AST.Conjunction(tree!, ParseInner(ref expression, depth));
                 }
                 else if (Re(disjunctionRegex, ref expression) != null)
                 {
-                    thisNode = new AST.Disjunction(tree!, ParseInner(ref expression));
+                    thisNode = new AST.Disjunction(tree!, ParseInner(ref expression, depth));
                 }
                 else if ((m = Re(itemOrFunctionRegex, ref expression)) != null)
                 {
@@ -231,8 +235,15 @@ namespace TPRandomizer
                 }
                 else if (expression.StartsWith(')'))
                 {
-                    // end of a subexpression. let the caller handle advancing the read pointeru
-                    break;
+                    if (depth > 0)
+                    {
+                        // end of a subexpression. let the caller handle advancing the read pointer
+                        break;
+                    }
+                    else
+                    {
+                        throw new Exception("Unexpected closing parenthesis");
+                    }
                 }
                 else
                 {

--- a/Generator/Randomizer.cs
+++ b/Generator/Randomizer.cs
@@ -873,26 +873,16 @@ namespace TPRandomizer
                             )
                             {
                                 // Parse the neighbour's requirements to find out if we can access it
-                                var areNeighbourRequirementsMet = false;
                                 /*Console.WriteLine(
                                     "Checking neighbor: "
                                         + Randomizer.Rooms.RoomDict[
                                             roomsToExplore[0].Exits[i].ConnectedArea
                                         ].RoomName
                                 );*/
-                                if (SSettings.logicRules == LogicRules.No_Logic)
-                                {
-                                    areNeighbourRequirementsMet = true;
-                                }
-                                else
-                                {
-                                    areNeighbourRequirementsMet = Logic.EvaluateRequirements(
-                                        roomsToExplore[0].RoomName,
-                                        roomsToExplore[0].Exits[i].Requirements
-                                    );
-                                }
-
-                                if ((bool)areNeighbourRequirementsMet == true)
+                                if (
+                                    SSettings.logicRules == LogicRules.No_Logic
+                                    || roomsToExplore[0].Exits[i].CachedRequirements().Evaluate()
+                                )
                                 {
                                     if (
                                         !Randomizer.Rooms.RoomDict[
@@ -1163,20 +1153,10 @@ namespace TPRandomizer
                                 }
                                 if (!currentCheck.hasBeenReached)
                                 {
-                                    var areCheckRequirementsMet = false;
-                                    if (SSettings.logicRules == LogicRules.No_Logic)
-                                    {
-                                        areCheckRequirementsMet = true;
-                                    }
-                                    else
-                                    {
-                                        areCheckRequirementsMet = Logic.EvaluateRequirements(
-                                            currentCheck.checkName,
-                                            currentCheck.requirements
-                                        );
-                                    }
-
-                                    if ((bool)areCheckRequirementsMet == true)
+                                    if (
+                                        SSettings.logicRules == LogicRules.No_Logic
+                                        || currentCheck.CachedRequirements().Evaluate()
+                                    )
                                     {
                                         if (currentCheck.itemWasPlaced)
                                         {


### PR DESCRIPTION
Complete rewrite of `Generator/Logic/LogicTokenizer.cs` and some associated refactors. On my machine, this makes logic evaluation run about ten times faster.

The gist of this changeset is that we now build explicit [abstract syntax trees](https://en.wikipedia.org/wiki/Abstract_syntax_tree) for each logic expression. These AST objects are reusable, so we can cache them between evaluations rather than parsing from scratch every time. The actual parser structure is a little different as well (it's a port of a rando logic parser I wrote for something else without reference to the original C# codebase), using a single-phase recursive descent parser instead of separate tokenize and parse steps, but as far as I can tell it produces identical results.

(I'm new to both C# and this codebase, constructive criticism welcome...)