### PR TITLE
feat: Added buttons to save and load settings string from local storage

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -889,6 +889,7 @@
             </button>
 
             <button
+              id="loadString"
               data-tooltip-text="Loads the string saved in the browser's local storage."
               onclick="loadSettingsString()"
             >

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <link rel="icon" target="_blank" href="/favicon.png" />
@@ -879,6 +879,26 @@
               ></path>
             </svg>
           </button>
+          <div style="margin-left: 8px">
+            <button
+              data-tooltip-text="This button will save the current seed in the browser&#39;s local storage. It is important to note that the seed will be erased when a new version of the generator is released."
+              onclick="saveSettingsString()"
+            >
+              Save string
+            </button>
+
+            <button
+              data-tooltip-text="Loads the string saved in the browser's local storage."
+              onclick="loadSettingsString()"
+            >
+              Load string
+            </button>
+            <div
+              id="loadFieldError"
+              class="fieldErrorText"
+              style="display: none"
+            ></div>
+          </div>
           <span id="combinedSettingsString" class="settingsStringValue"></span>
         </div>
 

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -879,6 +879,7 @@
               ></path>
             </svg>
           </button>
+          <span id="combinedSettingsString" class="settingsStringValue"></span>
           <div style="margin-left: 8px">
             <button
               data-tooltip-text="This button will save the current seed in the browser&#39;s local storage. It is important to note that the seed will be erased when a new version of the generator is released."
@@ -899,7 +900,6 @@
               style="display: none"
             ></div>
           </div>
-          <span id="combinedSettingsString" class="settingsStringValue"></span>
         </div>
 
         <!-- <div>SSettings (display only):</div>

--- a/packages/client/script.js
+++ b/packages/client/script.js
@@ -676,6 +676,61 @@ var arrayOfSettingsItems = [
   'openDotCheckbox',
 ];
 
+function saveSettingsString() {
+  const settingsString = $('#combinedSettingsString').text().trim();
+  const version = $('#envImageVersion').val();
+
+  if (!settingsString) {
+    console.warn('No settings string to save.');
+    return;
+  }
+
+  const payload = JSON.stringify({
+    settingsString,
+    version: version ?? null, // The explicit null check here is only for dev purposes. This should never happen in a production environment, and isn't a very critical feature anyways.
+  });
+
+  localStorage.setItem('settingsString', payload);
+}
+
+function loadSettingsString() {
+  const fieldErrorText = $('#loadFieldError');
+  const raw = localStorage.getItem('settingsString');
+
+  if (!raw) {
+    console.warn('No saved settings string.');
+    return;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    console.warn('Corrupted settings string.');
+    localStorage.removeItem('settingsString');
+    return;
+  }
+
+  const { settingsString, version } = parsed;
+
+  const currentVersion = $('#envImageVersion').val();
+  if (version != currentVersion) {
+    fieldErrorText.text(
+      'Your setting string was saved on a previous version of the generator, rendering it incompatible with the current version. Your saved setting string will now be deleted.'
+    );
+    localStorage.removeItem('settingsString');
+    return;
+  }
+
+  const error = populateFromSettingsString(settingsString);
+  if (error) {
+    fieldErrorText.text('Unable to understand those settings.').show();
+    return;
+  }
+
+  $('#combinedSettingsString').text(`${settingsString}`);
+}
+
 function parseSettingsString(settingsString) {
   settingsString = atob(settingsString);
   //Convert the settings string into a binary string to be interpreted.

--- a/packages/client/script.js
+++ b/packages/client/script.js
@@ -127,6 +127,11 @@ function onDomContentLoaded() {
   // their previous values.
   window.addEventListener('load', setSettingsString, { once: true });
 
+  // Hide the load string button if no strings are saved in local storage.
+  if (!localStorage.getItem('settingsString')) {
+    $('#loadString').hide();
+  }
+
   initSettingsModal();
   initGeneratingModal();
 
@@ -691,6 +696,8 @@ function saveSettingsString() {
   });
 
   localStorage.setItem('settingsString', payload);
+
+  $('#loadString').show();
 }
 
 function loadSettingsString() {
@@ -724,7 +731,11 @@ function loadSettingsString() {
 
   const error = populateFromSettingsString(settingsString);
   if (error) {
-    fieldErrorText.text('Unable to understand those settings.').show();
+    fieldErrorText
+      .text(
+        'Unable to understand the settings string saved in local storage. Please select new settings or enter a new settings string manually.'
+      )
+      .show();
     return;
   }
 


### PR DESCRIPTION
This PR adds a button to save the settings string to local storage, along with the randomizer version, and a button to load the string from local storage + check that the stored seed had the correct version.